### PR TITLE
AM-2851 CVE-2023-2976 guava 32.0.1-jre,suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ dependencies {
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
     implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk' , version: '5.10.9'
-    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.16.3'
     implementation group: 'javax.persistence', name: 'javax.persistence-api', version: '2.2'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.76'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,8 +4,4 @@
         <notes>https://tools.hmcts.net/jira/browse/AM-2839 jackson-databind</notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/AM-2851 guava</notes>
-        <cve>CVE-2023-2976</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2851
CVE-2023-2976 guava 32.0.1-jre

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
