### PR TITLE
AM-2923 CVE-2023-41080 tomcat upgraded to 9.0.80, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,7 +245,7 @@ dependencies {
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.21.1'
     implementation group: 'javax.persistence', name: 'javax.persistence-api', version: '2.2'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.80'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.78'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.80'
 
     implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,8 +4,4 @@
         <notes>https://tools.hmcts.net/jira/browse/AM-2839 jackson-databind</notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/AM-2923 tomcat</notes>
-        <cve>CVE-2023-41080</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2923
CVE-2023-41080 tomcat upgraded to 9.0.80

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
