### PR TITLE
AM-3068 Pitest failures in Nightly - pitest-junit5-plugin upgraded to…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def versions = [
         junit              : '5.9.3',
         lombok             : '1.18.30',
         gradlePitest       : '1.3.0',
-        pitest             : '1.15.1',
+        pitest             : '1.15.3',
         reformLogging      : '6.0.1',
         serenity           : '2.2.12',
         springBoot         : '2.7.17',
@@ -260,7 +260,7 @@ dependencies {
     testImplementation 'org.apiguardian:apiguardian-api:1.1.2'
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
-    pitest 'org.pitest:pitest-junit5-plugin:0.16'
+    pitest 'org.pitest:pitest-junit5-plugin:1.2.1'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3068
Pitest failures in Nightly - pitest-junit5-plugin upgraded to 1.2.1 allowing other pitest components to be upgraded to 1.15.x

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
